### PR TITLE
fix database deadlock by making grabber a local variable in Run()

### DIFF
--- a/internal/app/ftpgrab.go
+++ b/internal/app/ftpgrab.go
@@ -14,12 +14,11 @@ import (
 
 // FtpGrab represents an active ftpgrab object
 type FtpGrab struct {
-	cfg     *config.Config
-	cron    *cron.Cron
-	notif   *notif.Client
-	grabber *grabber.Client
-	jobID   cron.EntryID
-	locker  uint32
+	cfg    *config.Config
+	cron   *cron.Cron
+	notif  *notif.Client
+	jobID  cron.EntryID
+	locker uint32
 }
 
 // New creates new ftpgrab instance
@@ -80,14 +79,15 @@ func (fg *FtpGrab) Run() {
 	}
 
 	// Grabber client
-	if fg.grabber, err = grabber.New(fg.cfg.Download, fg.cfg.Db, fg.cfg.Server); err != nil {
+	grabCli, err := grabber.New(fg.cfg.Download, fg.cfg.Db, fg.cfg.Server)
+	if err != nil {
 		log.Error().Err(err).Msg("Cannot create grabber")
 		return
 	}
-	defer fg.grabber.Close()
+	defer grabCli.Close()
 
 	// List files
-	files := fg.grabber.ListFiles()
+	files := grabCli.ListFiles()
 	if len(files) == 0 {
 		log.Warn().Msg("No file found from the provided sources")
 		return
@@ -95,7 +95,7 @@ func (fg *FtpGrab) Run() {
 	log.Info().Msgf("%d file(s) found", len(files))
 
 	// Grab
-	jnl := fg.grabber.Grab(files)
+	jnl := grabCli.Grab(files)
 	jnl.Duration = time.Since(start)
 	log.Info().
 		Str("duration", time.Since(start).Round(time.Millisecond).String()).
@@ -115,9 +115,6 @@ func (fg *FtpGrab) Run() {
 func (fg *FtpGrab) Close() {
 	if fg == nil {
 		return
-	}
-	if fg.grabber != nil {
-		fg.grabber.Close()
 	}
 	if fg.cron != nil {
 		fg.cron.Stop()


### PR DESCRIPTION
## Summary
- The grabber client is stored as a struct field and persists between cron-scheduled runs. When `Run()` returns early due to an error, the deferred `Close()` may not execute properly, leaving the BoltDB database locked. Subsequent runs then timeout trying to open the database, requiring a container restart.
- Make grabber a local variable within `Run()` so each invocation gets a fresh instance with proper cleanup via `defer`. Remove the now-unused `grabber` field from `FtpGrab` and the redundant `Close()` call in `FtpGrab.Close()`.

## Test plan
- [x] All existing tests pass
- [ ] Run with cron schedule and verify consecutive runs don't deadlock
- [ ] Verify graceful shutdown still works (signal during active run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)