### PR TITLE
timeout FTP Quit() to prevent blocking on unresponsive servers

### DIFF
--- a/internal/server/ftp/client.go
+++ b/internal/server/ftp/client.go
@@ -169,7 +169,18 @@ func (c *Client) Retrieve(path string, dest io.Writer) error {
 
 // Close closes ftp connection
 func (c *Client) Close() error {
-	return c.ftp.Quit()
+	done := make(chan error, 1)
+	go func() {
+		done <- c.ftp.Quit()
+	}()
+
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(*c.cfg.Timeout):
+		log.Warn().Dur("timeout", *c.cfg.Timeout).Msg("Cannot close ftp connection, quit timed out")
+		return fmt.Errorf("quit timed out after %s", *c.cfg.Timeout)
+	}
 }
 
 func newTimeoutDialFunc(timeout time.Duration, mode tlsMode, tlsConfig *tls.Config) func(network, address string) (net.Conn, error) {


### PR DESCRIPTION
## Summary
- The safe shutdown changes in #479 prevent panics when `Quit()` is called before initialization, but a hung `Quit()` on an unresponsive server can still block the `Close()` call indefinitely.
- Wrap `Quit()` with the configured timeout so cleanup never blocks longer than necessary. Uses a buffered channel to prevent goroutine leaks on the send path.

## Test plan
- [x] All existing tests pass
- [ ] Verify `Close()` returns within the configured timeout when server is unresponsive
- [ ] Verify normal `Close()` behavior is unchanged when server responds promptly

🤖 Generated with [Claude Code](https://claude.com/claude-code)