### PR TITLE
detect slow transfers and retry list operations with reconnect

### DIFF
--- a/docs/config/server/ftp.md
+++ b/docs/config/server/ftp.md
@@ -252,6 +252,23 @@ Controls whether a client verifies the server’s certificate chain and host nam
 !!! abstract "Environment variables"
     * `FTPGRAB_SERVER_FTP_INSECURESKIPVERIFY`
 
+### `minSpeed`
+
+Minimum acceptable sustained download speed in KB/s (kilobytes per second). After an initial
+warmup interval, transfers whose throughput drops below this threshold for two consecutive
+30-second check intervals are aborted and retried with a fresh connection. Set to `0` to
+disable. For reference: `1024` = 1 MB/s, `128` ≈ 1 Mbit/s. (default `0` / disabled)
+
+!!! example "Config file"
+    ```yaml
+    server:
+      ftp:
+        minSpeed: 1024
+    ```
+
+!!! abstract "Environment variables"
+    * `FTPGRAB_SERVER_FTP_MINSPEED`
+
 ### `logTrace`
 
 Enable low-level FTP log. Works only if global log level is debug. (default `false`)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -59,6 +59,7 @@ func TestLoadFile(t *testing.T) {
 						ExplicitTLS:        utl.NewFalse(),
 						InsecureSkipVerify: utl.NewFalse(),
 						LogTrace:           utl.NewFalse(),
+						MinSpeed:           utl.NewInt64(0),
 					},
 				},
 				Download: &Download{
@@ -166,6 +167,7 @@ func TestLoadEnv(t *testing.T) {
 						ExplicitTLS:        utl.NewFalse(),
 						InsecureSkipVerify: utl.NewFalse(),
 						LogTrace:           utl.NewFalse(),
+						MinSpeed:           utl.NewInt64(0),
 					},
 				},
 				Download: &Download{
@@ -338,6 +340,7 @@ func TestLoadMixed(t *testing.T) {
 						ExplicitTLS:        utl.NewFalse(),
 						InsecureSkipVerify: utl.NewFalse(),
 						LogTrace:           utl.NewFalse(),
+						MinSpeed:           utl.NewInt64(0),
 					},
 				},
 				Download: &Download{

--- a/internal/config/server_ftp.go
+++ b/internal/config/server_ftp.go
@@ -24,6 +24,7 @@ type ServerFTP struct {
 	ExplicitTLS        *bool          `yaml:"explicitTLS,omitempty" json:"explicitTLS,omitempty"`
 	InsecureSkipVerify *bool          `yaml:"insecureSkipVerify,omitempty" json:"insecureSkipVerify,omitempty"`
 	LogTrace           *bool          `yaml:"logTrace,omitempty" json:"logTrace,omitempty"`
+	MinSpeed           *int64         `yaml:"minSpeed,omitempty" json:"minSpeed,omitempty"`
 }
 
 // GetDefaults gets the default values
@@ -46,4 +47,5 @@ func (s *ServerFTP) SetDefaults() {
 	s.ExplicitTLS = utl.NewFalse()
 	s.InsecureSkipVerify = utl.NewFalse()
 	s.LogTrace = utl.NewFalse()
+	s.MinSpeed = utl.NewInt64(0)
 }

--- a/internal/grabber/file.go
+++ b/internal/grabber/file.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path"
 
+	"github.com/crazy-max/ftpgrab/v7/internal/server/ftp"
 	"github.com/rs/zerolog/log"
 )
 
@@ -28,17 +29,33 @@ func (c *Client) ListFiles() []File {
 			dest = path.Join(dest, src)
 		}
 
-		files = append(files, c.readDir(src, src, dest)...)
+		files = append(files, c.readDir(src, src, dest, 0)...)
 	}
 
 	return files
 }
 
-func (c *Client) readDir(base string, srcdir string, destdir string) []File {
+func (c *Client) readDir(base string, srcdir string, destdir string, retry int) []File {
 	var files []File
 
 	items, err := c.server.ReadDir(srcdir)
 	if err != nil {
+		// If list operation timed out, reconnect and retry
+		if err == ftp.ErrListTimeout {
+			retry++
+			log.Warn().Str("source", base).Msgf("List operation timed out, retry %d/%d", retry, c.config.Retry)
+			if retry == c.config.Retry {
+				log.Error().Str("source", base).Msgf("Cannot read directory %s after %d retries", srcdir, retry)
+				return []File{}
+			}
+			log.Warn().Str("source", base).Msg("Reconnecting to server after list timeout")
+			if reconnectErr := c.reconnect(); reconnectErr != nil {
+				log.Error().Err(reconnectErr).Str("source", base).Msg("Cannot reconnect to server")
+				return []File{}
+			}
+			// Retry with incremented retry count
+			return c.readDir(base, srcdir, destdir, retry)
+		}
 		log.Error().Err(err).Str("source", base).Msgf("Cannot read directory %s", srcdir)
 		return []File{}
 	}
@@ -55,7 +72,7 @@ func (c *Client) readFile(base string, srcdir string, destdir string, file os.Fi
 	destfile := path.Join(destdir, file.Name())
 
 	if file.IsDir() {
-		return c.readDir(base, srcfile, destfile)
+		return c.readDir(base, srcfile, destfile, 0)
 	}
 
 	return []File{

--- a/internal/grabber/grabber.go
+++ b/internal/grabber/grabber.go
@@ -21,10 +21,11 @@ import (
 
 // Client represents an active grabber object
 type Client struct {
-	config     *config.Download
-	db         *db.Client
-	server     *server.Client
-	tempdirRun string
+	config       *config.Download
+	db           *db.Client
+	server       *server.Client
+	serverConfig *config.Server
+	tempdirRun   string
 }
 
 // New creates new grabber instance
@@ -63,9 +64,10 @@ func New(dlConfig *config.Download, dbConfig *config.Db, serverConfig *config.Se
 	}
 
 	client = &Client{
-		config: dlConfig,
-		db:     dbCli,
-		server: serverctl,
+		config:       dlConfig,
+		db:           dbCli,
+		server:       serverctl,
+		serverConfig: serverConfig,
 	}
 
 	if *dlConfig.TempFirst {
@@ -75,6 +77,30 @@ func New(dlConfig *config.Download, dbConfig *config.Db, serverConfig *config.Se
 	}
 
 	return client, nil
+}
+
+func (c *Client) reconnect() error {
+	if err := c.server.Close(); err != nil {
+		log.Warn().Err(err).Msg("Cannot close server connection during reconnect")
+	}
+
+	var serverCli *server.Client
+	var err error
+
+	if c.serverConfig.FTP != nil {
+		serverCli, err = ftp.New(c.serverConfig.FTP)
+	} else if c.serverConfig.SFTP != nil {
+		serverCli, err = sftp.New(c.serverConfig.SFTP)
+	} else {
+		return errors.New("No server defined")
+	}
+
+	if err != nil {
+		return err
+	}
+
+	c.server = serverCli
+	return nil
 }
 
 func (c *Client) Grab(files []File) journal.Journal {
@@ -156,6 +182,16 @@ func (c *Client) download(file File, retry int) *journal.Entry {
 			entry.Level = journal.EntryLevelError
 			entry.Text = fmt.Sprintf("Cannot download file: %v", err)
 		} else {
+			// If transfer was aborted due to slow speed, reconnect
+			if err == ftp.ErrSlowTransfer {
+				sublogger.Warn().Msg("Transfer aborted due to slow speed, reconnecting to server")
+				if reconnectErr := c.reconnect(); reconnectErr != nil {
+					sublogger.Error().Err(reconnectErr).Msg("Cannot reconnect to server")
+					entry.Level = journal.EntryLevelError
+					entry.Text = fmt.Sprintf("Cannot reconnect to server: %v", reconnectErr)
+					return entry
+				}
+			}
 			return c.download(file, retry)
 		}
 	} else {

--- a/internal/server/ftp/client.go
+++ b/internal/server/ftp/client.go
@@ -2,6 +2,7 @@ package ftp
 
 import (
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -16,6 +17,68 @@ import (
 	"github.com/jlaffaye/ftp"
 	"github.com/rs/zerolog/log"
 )
+
+const (
+	// checkInterval is how often to check download speed during transfers.
+	checkInterval = 30 * time.Second
+	// minSlowChecks is the number of consecutive slow checks before aborting.
+	minSlowChecks = 2
+)
+
+var (
+	// ErrSlowTransfer is returned when sustained throughput drops below the minimum speed.
+	ErrSlowTransfer = errors.New("transfer speed too slow, reconnecting")
+	// ErrListTimeout is returned when a List operation exceeds the configured timeout.
+	ErrListTimeout = errors.New("list operation timed out")
+)
+
+// speedMonitor wraps an io.Reader to abort transfers whose sustained
+// throughput drops below minSpeed. Unlike TimeoutConn (which catches
+// complete stalls at the TCP level), this detects slow trickles that
+// would otherwise keep the connection alive indefinitely.
+type speedMonitor struct {
+	reader          io.Reader
+	lastCheck       time.Time
+	lastBytes       int64
+	totalBytes      int64
+	minSpeed        int64
+	interval        time.Duration
+	consecutiveSlow int
+}
+
+func (s *speedMonitor) Read(p []byte) (n int, err error) {
+	n, err = s.reader.Read(p)
+	s.totalBytes += int64(n)
+
+	now := time.Now()
+	if now.Sub(s.lastCheck) >= s.interval {
+		elapsed := now.Sub(s.lastCheck).Seconds()
+		bytesSinceCheck := s.totalBytes - s.lastBytes
+
+		if elapsed > 0 {
+			speed := float64(bytesSinceCheck) / elapsed
+			if speed < float64(s.minSpeed) && s.lastBytes > 0 {
+				s.consecutiveSlow++
+				log.Warn().
+					Float64("speed_bps", speed).
+					Int64("min_speed_bps", s.minSpeed).
+					Int("consecutive_slow", s.consecutiveSlow).
+					Msgf("Transfer speed below threshold (%d/%d)", s.consecutiveSlow, minSlowChecks)
+
+				if s.consecutiveSlow >= minSlowChecks {
+					return n, ErrSlowTransfer
+				}
+			} else {
+				s.consecutiveSlow = 0
+			}
+		}
+
+		s.lastCheck = now
+		s.lastBytes = s.totalBytes
+	}
+
+	return n, err
+}
 
 type ftpConn interface {
 	Login(username, password string) error
@@ -126,9 +189,30 @@ func (c *Client) ReadDir(dir string) ([]os.FileInfo, error) {
 	if *c.cfg.EscapeRegexpMeta {
 		dir = regexp.QuoteMeta(dir)
 	}
-	files, err := c.ftp.List(dir)
-	if err != nil {
-		return nil, err
+
+	// Add timeout to List operation to prevent hanging
+	type listResult struct {
+		files []*ftp.Entry
+		err   error
+	}
+	resultCh := make(chan listResult, 1)
+
+	go func() {
+		f, e := c.ftp.List(dir)
+		resultCh <- listResult{files: f, err: e}
+	}()
+
+	select {
+	case result := <-resultCh:
+		files = result.files
+		if err := result.err; err != nil {
+			return nil, err
+		}
+	case <-time.After(*c.cfg.Timeout):
+		log.Warn().
+			Dur("timeout", *c.cfg.Timeout).
+			Msg("Cannot list directory, timeout reached")
+		return nil, ErrListTimeout
 	}
 
 	var entries []os.FileInfo
@@ -163,7 +247,17 @@ func (c *Client) Retrieve(path string, dest io.Writer) error {
 	}
 	defer resp.Close()
 
-	_, err = io.Copy(dest, resp)
+	var src io.Reader = resp
+	if *c.cfg.MinSpeed > 0 {
+		src = &speedMonitor{
+			reader:    resp,
+			lastCheck: time.Now(),
+			minSpeed:  *c.cfg.MinSpeed * 1024, // convert KB/s to bytes/s
+			interval:  checkInterval,
+		}
+	}
+
+	_, err = io.Copy(dest, src)
 	return err
 }
 

--- a/pkg/utl/utl.go
+++ b/pkg/utl/utl.go
@@ -78,6 +78,11 @@ func NewTrue() *bool {
 	return &b
 }
 
+// NewInt64 returns an int64 pointer
+func NewInt64(n int64) *int64 {
+	return &n
+}
+
 // NewDuration returns a duration pointer
 func NewDuration(duration time.Duration) *time.Duration {
 	return &duration


### PR DESCRIPTION
## Summary
- `TimeoutConn` (#478) catches complete stalls at the TCP level, but a slow trickle can keep the connection alive indefinitely. Add a `speedMonitor` wrapper that aborts transfers when sustained throughput drops below the configured `minSpeed` for consecutive check intervals.
- The `minSpeed` threshold is configurable via the `minSpeed` server option (`FTPGRAB_SERVER_FTP_MINSPEED`) in KB/s and defaults to `0` (disabled).
- Add a timeout to FTP `List()` operations using the configured `timeout` duration. When a list or download fails due to timeout or slow speed, reconnect to the server and retry up to the configured retry count.
- Store the server config in the grabber client to support reconnection and add a `reconnect()` method that cleanly closes the old connection before establishing a new one.

## Test plan
- [x] All existing tests pass
- [ ] Configure `minSpeed` and verify slow transfers are aborted and retried
- [ ] Verify `minSpeed=0` disables the speed monitor (default behavior unchanged)
- [ ] Simulate a hung `List()` and verify it times out and retries with reconnect
- [ ] Verify normal-speed transfers are unaffected by the speed monitor

🤖 Generated with [Claude Code](https://claude.com/claude-code)