### PR TITLE
reconnect FTP sessions after timeout-poisoned transfers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/go-gomail/gomail v0.0.0-20160411212932-81ebce5c23df
 	github.com/go-playground/validator/v10 v10.30.2
 	github.com/hako/durafmt v0.0.0-20210608085754-5c1018a4e16b
+	github.com/hashicorp/go-multierror v1.1.1
 	github.com/ilya1st/rotatewriter v0.0.0-20171126183947-3df0c1a3ed6d
 	github.com/jlaffaye/ftp v0.2.0
 	github.com/matcornic/hermes/v2 v2.1.0
@@ -39,7 +40,6 @@ require (
 	github.com/gorilla/css v1.0.0 // indirect
 	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
-	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/huandu/xstrings v1.2.0 // indirect
 	github.com/imdario/mergo v0.3.6 // indirect
 	github.com/jaytaylor/html2text v0.0.0-20180606194806-57d518f124b0 // indirect

--- a/internal/server/ftp/client.go
+++ b/internal/server/ftp/client.go
@@ -36,6 +36,7 @@ type Client struct {
 	addr        string
 	username    string
 	password    string
+	connectErr  error
 	ftp         ftpConn
 	dial        func(addr string, options ...ftp.DialOption) (ftpConn, error)
 	dialOptions []ftp.DialOption
@@ -147,6 +148,7 @@ func (c *Client) connect() error {
 			return err
 		}
 	}
+	c.connectErr = nil
 	c.ftp = conn
 	return nil
 }
@@ -155,7 +157,14 @@ func (c *Client) ensureConnected() error {
 	if c.ftp != nil {
 		return nil
 	}
-	return c.connect()
+	if c.connectErr != nil {
+		return c.connectErr
+	}
+	if err := c.connect(); err != nil {
+		c.connectErr = err
+		return err
+	}
+	return nil
 }
 
 func (c *Client) handleTransferError(err error) error {

--- a/internal/server/ftp/client.go
+++ b/internal/server/ftp/client.go
@@ -13,6 +13,7 @@ import (
 	"github.com/crazy-max/ftpgrab/v7/internal/logging"
 	"github.com/crazy-max/ftpgrab/v7/internal/server"
 	"github.com/crazy-max/ftpgrab/v7/pkg/utl"
+	"github.com/hashicorp/go-multierror"
 	"github.com/jlaffaye/ftp"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
@@ -24,16 +25,37 @@ import (
 type ftpConn interface {
 	Login(username, password string) error
 	List(path string) ([]*ftp.Entry, error)
-	Retr(path string) (*ftp.Response, error)
+	Retr(path string) (io.ReadCloser, error)
 	Quit() error
 }
 
 // Client represents an active ftp object
 type Client struct {
 	*server.Client
-	cfg     *config.ServerFTP
-	ftp     ftpConn
-	pathenc pathEncoder
+	cfg         *config.ServerFTP
+	addr        string
+	username    string
+	password    string
+	ftp         ftpConn
+	dial        func(addr string, options ...ftp.DialOption) (ftpConn, error)
+	dialOptions []ftp.DialOption
+	pathenc     pathEncoder
+}
+
+type serverConn struct {
+	*ftp.ServerConn
+}
+
+func (c serverConn) Retr(path string) (io.ReadCloser, error) {
+	return c.ServerConn.Retr(path)
+}
+
+func defaultDialFTP(addr string, options ...ftp.DialOption) (ftpConn, error) {
+	conn, err := ftp.Dial(addr, options...)
+	if err != nil {
+		return nil, err
+	}
+	return serverConn{ServerConn: conn}, nil
 }
 
 type tlsMode uint8
@@ -58,7 +80,11 @@ func getTLSMode(cfg *config.ServerFTP) tlsMode {
 // New creates new ftp instance
 func New(cfg *config.ServerFTP) (*server.Client, error) {
 	var err error
-	client := &Client{cfg: cfg}
+	client := &Client{
+		cfg:  cfg,
+		addr: fmt.Sprintf("%s:%d", cfg.Host, cfg.Port),
+		dial: defaultDialFTP,
+	}
 	mode := getTLSMode(cfg)
 	if client.pathenc, err = newPathEnc(cfg.PathEncoding); err != nil {
 		return nil, err
@@ -84,10 +110,7 @@ func New(cfg *config.ServerFTP) (*server.Client, error) {
 	case tlsModeExplicit:
 		ftpConfig = append(ftpConfig, ftp.DialWithExplicitTLS(tlsConfig))
 	}
-
-	if client.ftp, err = ftp.Dial(fmt.Sprintf("%s:%d", cfg.Host, cfg.Port), ftpConfig...); err != nil {
-		return nil, err
-	}
+	client.dialOptions = ftpConfig
 
 	username, err := utl.GetSecret(cfg.Username, cfg.UsernameFile)
 	if err != nil {
@@ -97,25 +120,52 @@ func New(cfg *config.ServerFTP) (*server.Client, error) {
 	if err != nil {
 		log.Warn().Err(err).Msg("Cannot retrieve password secret for ftp server")
 	}
+	client.username = username
+	client.password = password
 
-	if err = client.login(username, password); err != nil {
+	if err = client.connect(); err != nil {
 		return nil, err
 	}
 
 	return &server.Client{Handler: client}, err
 }
 
-func (c *Client) login(username, password string) error {
-	if username == "" {
-		return nil
+func (c *Client) connect() error {
+	dial := c.dial
+	if dial == nil {
+		dial = defaultDialFTP
 	}
-	if err := c.ftp.Login(username, password); err != nil {
-		if closeErr := c.ftp.Quit(); closeErr != nil {
-			log.Warn().Err(closeErr).Msg("Cannot close ftp connection after login failure")
-		}
+	conn, err := dial(c.addr, c.dialOptions...)
+	if err != nil {
 		return err
 	}
+	if c.username != "" {
+		if err := conn.Login(c.username, c.password); err != nil {
+			if closeErr := conn.Quit(); closeErr != nil {
+				log.Warn().Err(closeErr).Msg("Cannot close ftp connection after login failure")
+			}
+			return err
+		}
+	}
+	c.ftp = conn
 	return nil
+}
+
+func (c *Client) ensureConnected() error {
+	if c.ftp != nil {
+		return nil
+	}
+	return c.connect()
+}
+
+func (c *Client) handleTransferError(err error) error {
+	if !isTimeoutError(err) {
+		return err
+	}
+	if closeErr := c.Close(); closeErr != nil {
+		log.Warn().Err(closeErr).Msg("Cannot close ftp connection after transfer timeout")
+	}
+	return err
 }
 
 // Common return common configuration
@@ -136,9 +186,12 @@ func (c *Client) ReadDir(dir string) ([]os.FileInfo, error) {
 	if err != nil {
 		return nil, err
 	}
+	if err := c.ensureConnected(); err != nil {
+		return nil, err
+	}
 	files, err := c.ftp.List(dir)
 	if err != nil {
-		return nil, err
+		return nil, c.handleTransferError(err)
 	}
 
 	var entries []os.FileInfo
@@ -168,25 +221,35 @@ func (c *Client) ReadDir(dir string) ([]os.FileInfo, error) {
 	return entries, nil
 }
 
-// Retrieve file "path" from server and write bytes to "dest".
-func (c *Client) Retrieve(path string, dest io.Writer) error {
-	path, err := c.pathenc.Encode(path)
+// Retrieve file from server and write bytes to "dest".
+func (c *Client) Retrieve(filename string, dest io.Writer) error {
+	filename, err := c.pathenc.Encode(filename)
 	if err != nil {
 		return err
 	}
-	resp, err := c.ftp.Retr(path)
-	if err != nil {
+	if err := c.ensureConnected(); err != nil {
 		return err
 	}
-	defer resp.Close()
-
-	_, err = io.Copy(dest, resp)
-	return err
+	resp, err := c.ftp.Retr(filename)
+	if err != nil {
+		return c.handleTransferError(err)
+	}
+	_, copyErr := io.Copy(dest, resp)
+	closeErr := resp.Close()
+	if err := multierror.Append(copyErr, closeErr).ErrorOrNil(); err != nil {
+		return c.handleTransferError(err)
+	}
+	return nil
 }
 
 // Close closes ftp connection
 func (c *Client) Close() error {
-	return c.ftp.Quit()
+	if c.ftp == nil {
+		return nil
+	}
+	conn := c.ftp
+	c.ftp = nil
+	return conn.Quit()
 }
 
 func newTimeoutDialFunc(timeout time.Duration, mode tlsMode, tlsConfig *tls.Config) func(network, address string) (net.Conn, error) {
@@ -204,6 +267,16 @@ func newTimeoutDialFunc(timeout time.Duration, mode tlsMode, tlsConfig *tls.Conf
 		useTLS = mode == tlsModeExplicit
 		return conn, nil
 	}
+}
+
+func isTimeoutError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var timeoutErr interface {
+		Timeout() bool
+	}
+	return errors.As(err, &timeoutErr) && timeoutErr.Timeout()
 }
 
 type pathEncoder struct {

--- a/internal/server/ftp/client_test.go
+++ b/internal/server/ftp/client_test.go
@@ -1,15 +1,18 @@
 package ftp
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"errors"
+	"io"
 	"net"
 	"testing"
 	"time"
 
 	"github.com/crazy-max/ftpgrab/v7/internal/config"
 	"github.com/crazy-max/ftpgrab/v7/pkg/utl"
+	"github.com/hashicorp/go-multierror"
 	ftplib "github.com/jlaffaye/ftp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -26,6 +29,7 @@ type stubFTPConn struct {
 	quitCall    int
 	retrErr     error
 	retrPath    string
+	retrResp    io.ReadCloser
 }
 
 func (c *stubFTPConn) Login(_, _ string) error {
@@ -37,14 +41,44 @@ func (c *stubFTPConn) List(path string) ([]*ftplib.Entry, error) {
 	return c.listEntries, c.listErr
 }
 
-func (c *stubFTPConn) Retr(path string) (*ftplib.Response, error) {
+func (c *stubFTPConn) Retr(path string) (io.ReadCloser, error) {
 	c.retrPath = path
-	return nil, c.retrErr
+	return c.retrResp, c.retrErr
 }
 
 func (c *stubFTPConn) Quit() error {
 	c.quitCall++
 	return c.quitErr
+}
+
+type stubReadCloser struct {
+	readErr  error
+	closeErr error
+	data     *bytes.Buffer
+}
+
+func (r *stubReadCloser) Read(p []byte) (int, error) {
+	if r.readErr != nil {
+		return 0, r.readErr
+	}
+	if r.data == nil {
+		return 0, io.EOF
+	}
+	return r.data.Read(p)
+}
+
+func (r *stubReadCloser) Close() error {
+	return r.closeErr
+}
+
+type timeoutError struct{}
+
+func (timeoutError) Error() string {
+	return "i/o timeout"
+}
+
+func (timeoutError) Timeout() bool {
+	return true
 }
 
 func TestGetTLSMode(t *testing.T) {
@@ -152,27 +186,49 @@ func TestNewTimeoutDialFunc(t *testing.T) {
 	})
 }
 
-func TestClientLogin(t *testing.T) {
+func TestClientConnect(t *testing.T) {
 	t.Run("skips login without username", func(t *testing.T) {
 		conn := &stubFTPConn{}
-		client := &Client{ftp: conn}
-		require.NoError(t, client.login("", "secret"))
+		client := &Client{
+			addr: "ftp.example:21",
+			dial: func(_ string, _ ...ftplib.DialOption) (ftpConn, error) {
+				return conn, nil
+			},
+		}
+		require.NoError(t, client.connect())
 		assert.Equal(t, 0, conn.quitCall)
+		assert.Equal(t, conn, client.ftp)
 	})
 
 	t.Run("closes connection when login fails", func(t *testing.T) {
 		conn := &stubFTPConn{loginErr: errors.New("boom")}
-		client := &Client{ftp: conn}
-		err := client.login("user", "secret")
+		client := &Client{
+			addr:     "ftp.example:21",
+			username: "user",
+			password: "secret",
+			dial: func(_ string, _ ...ftplib.DialOption) (ftpConn, error) {
+				return conn, nil
+			},
+		}
+		err := client.connect()
 		require.EqualError(t, err, "boom")
 		assert.Equal(t, 1, conn.quitCall)
+		assert.Nil(t, client.ftp)
 	})
 
 	t.Run("does not close connection on successful login", func(t *testing.T) {
 		conn := &stubFTPConn{}
-		client := &Client{ftp: conn}
-		require.NoError(t, client.login("user", "secret"))
+		client := &Client{
+			addr:     "ftp.example:21",
+			username: "user",
+			password: "secret",
+			dial: func(_ string, _ ...ftplib.DialOption) (ftpConn, error) {
+				return conn, nil
+			},
+		}
+		require.NoError(t, client.connect())
 		assert.Equal(t, 0, conn.quitCall)
+		assert.Equal(t, conn, client.ftp)
 	})
 }
 
@@ -239,6 +295,95 @@ func TestRetrieveEncodesPath(t *testing.T) {
 	err = client.Retrieve("/Проекты/Инструкция.txt", nil)
 	require.EqualError(t, err, "stop")
 	assert.Equal(t, mustEncodeWindows1251(t, "/Проекты/Инструкция.txt"), conn.retrPath)
+}
+
+func TestReadDirReconnectsAfterTimeout(t *testing.T) {
+	firstConn := &stubFTPConn{
+		listErr: multierror.Append(errors.New("data stalled"), timeoutError{}),
+	}
+	secondConn := &stubFTPConn{
+		listEntries: []*ftplib.Entry{
+			{Name: "ok.txt", Type: ftplib.EntryTypeFile},
+		},
+	}
+
+	dialCalls := 0
+	client := &Client{
+		cfg: &config.ServerFTP{EscapeRegexpMeta: utl.NewFalse()},
+		ftp: firstConn,
+		dial: func(_ string, _ ...ftplib.DialOption) (ftpConn, error) {
+			dialCalls++
+			if dialCalls == 1 {
+				return secondConn, nil
+			}
+			return nil, errors.New("unexpected dial")
+		},
+	}
+
+	_, err := client.ReadDir("/source")
+	require.Error(t, err)
+	assert.Equal(t, 1, firstConn.quitCall)
+	assert.Nil(t, client.ftp)
+
+	entries, err := client.ReadDir("/source")
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "ok.txt", entries[0].Name())
+	assert.Equal(t, 1, dialCalls)
+	assert.Equal(t, secondConn, client.ftp)
+}
+
+func TestReadDirKeepsConnectionAfterNonTimeoutError(t *testing.T) {
+	conn := &stubFTPConn{listErr: errors.New("permission denied")}
+	client := &Client{
+		cfg: &config.ServerFTP{EscapeRegexpMeta: utl.NewFalse()},
+		ftp: conn,
+	}
+
+	_, err := client.ReadDir("/source")
+	require.EqualError(t, err, "permission denied")
+	assert.Equal(t, 0, conn.quitCall)
+	assert.Equal(t, conn, client.ftp)
+}
+
+func TestRetrieveReconnectsAfterTimeoutClose(t *testing.T) {
+	firstConn := &stubFTPConn{
+		retrResp: &stubReadCloser{
+			data:     bytes.NewBufferString("payload"),
+			closeErr: timeoutError{},
+		},
+	}
+	secondConn := &stubFTPConn{
+		retrResp: &stubReadCloser{
+			data: bytes.NewBufferString("fresh"),
+		},
+	}
+
+	dialCalls := 0
+	client := &Client{
+		ftp: firstConn,
+		dial: func(_ string, _ ...ftplib.DialOption) (ftpConn, error) {
+			dialCalls++
+			if dialCalls == 1 {
+				return secondConn, nil
+			}
+			return nil, errors.New("unexpected dial")
+		},
+	}
+
+	var firstDest bytes.Buffer
+	err := client.Retrieve("/file.txt", &firstDest)
+	require.Error(t, err)
+	assert.Equal(t, "payload", firstDest.String())
+	assert.Equal(t, 1, firstConn.quitCall)
+	assert.Nil(t, client.ftp)
+
+	var secondDest bytes.Buffer
+	err = client.Retrieve("/file.txt", &secondDest)
+	require.NoError(t, err)
+	assert.Equal(t, "fresh", secondDest.String())
+	assert.Equal(t, 1, dialCalls)
+	assert.Equal(t, secondConn, client.ftp)
 }
 
 func mustEncodeWindows1251(t *testing.T, value string) string {

--- a/internal/server/ftp/client_test.go
+++ b/internal/server/ftp/client_test.go
@@ -333,6 +333,32 @@ func TestReadDirReconnectsAfterTimeout(t *testing.T) {
 	assert.Equal(t, secondConn, client.ftp)
 }
 
+func TestReadDirDoesNotRetryReconnectAfterFailedReconnect(t *testing.T) {
+	firstConn := &stubFTPConn{
+		listErr: multierror.Append(errors.New("data stalled"), timeoutError{}),
+	}
+
+	dialCalls := 0
+	client := &Client{
+		cfg: &config.ServerFTP{EscapeRegexpMeta: utl.NewFalse()},
+		ftp: firstConn,
+		dial: func(_ string, _ ...ftplib.DialOption) (ftpConn, error) {
+			dialCalls++
+			return nil, errors.New("tls: first record does not look like a TLS handshake")
+		},
+	}
+
+	_, err := client.ReadDir("/source-a")
+	require.Error(t, err)
+	assert.Equal(t, 1, firstConn.quitCall)
+	assert.Nil(t, client.ftp)
+
+	_, err = client.ReadDir("/source-b")
+	require.EqualError(t, err, "tls: first record does not look like a TLS handshake")
+	assert.Equal(t, 1, dialCalls)
+	assert.EqualError(t, client.connectErr, "tls: first record does not look like a TLS handshake")
+}
+
 func TestReadDirKeepsConnectionAfterNonTimeoutError(t *testing.T) {
 	conn := &stubFTPConn{listErr: errors.New("permission denied")}
 	client := &Client{


### PR DESCRIPTION
fixes #507 

The FTP client now keeps the state needed to reconnect lazily after timeout-shaped transfer failures. `Retrieve` also stops ignoring `resp.Close()` failures, because that close path is where the trailing FTP control response timeout is surfaced by `jlaffaye/ftp` module.

#507 describes a real failure mode where one stalled transfer poisons the control connection and turns a short run into minutes of repeated failures. FTP has no reliable in-band resync after that state is corrupted, so the correct recovery path is to discard the connection and reconnect before the next operation.